### PR TITLE
Allow translating "personal config update"

### DIFF
--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -158,5 +158,6 @@
 	"mwe-recwiz-wmcategory-limit-help": "Help message displayed in a popup nextto the limit field, in the 'Wikimedia Category' generator dialog box.",
 	"mwe-recwiz-list-error-nopage": "Error message indicating that no page was entered.",
 	"mwe-recwiz-error-pagemissing": "Error message indicating that the given page cannot be found.",
-	"mwe-recwiz-error-nowiki": "Error message indicating that the generator cannot find a Wikipedia or a Wiktionary in the selected language."
+	"mwe-recwiz-error-nowiki": "Error message indicating that the generator cannot find a Wikipedia or a Wiktionary in the selected language.",
+	"mwe-personal-config-update": "personal config update"
 }

--- a/modules/vue/rw.vue.speaker.js
+++ b/modules/vue/rw.vue.speaker.js
@@ -283,7 +283,7 @@
 					format: 'json',
 					title: 'User:' + mw.config.get( 'wgUserName' ) + '/RecordWizard.json',
 					text: JSON.stringify( userConfig ),
-					summary: 'personal config update',
+					summary: mw.msg( 'mwe-personal-config-update' ),
 					recreate: 1
 				} ).fail( function () {
 					// TODO: manage errors


### PR DESCRIPTION
This string appears in the Recent change when an user modify his/her language settings.
I am clearly not a Javascript expert so it is possible that this patch does not work at all.