### PR TITLE
Update ext.studio.css

### DIFF
--- a/stylesheets/ext.studio.css
+++ b/stylesheets/ext.studio.css
@@ -271,7 +271,7 @@
 .mwe-rw-core {
 	display: flex;
 	flex-wrap: wrap-reverse;
-	flex-direction: column;
+	/* flex-direction: column; */
 	align-items: center;
 
 	margin-left: 35px;


### PR DESCRIPTION
Fix regression bug in video recording. See https://github.com/lingua-libre/RecordWizard/commit/0fb2d8e9b62ee5d765dba1d178fdcd6c7ae343c6

Hello @Poslovitch ,
The `flex-direction: column` mess the video recording outline.
![Screenshot from 2023-07-27 18-22-33](https://github.com/lingua-libre/RecordWizard/assets/1420189/bb178ad5-4790-4450-be2c-94d938bdcc2b)
![Screenshot from 2023-07-27 18-22-26](https://github.com/lingua-libre/RecordWizard/assets/1420189/ecaa355c-bca1-494d-8311-cdab9906c596)

The audio recording seems working properly without this `flex-direction: column` , in both desktop and mobile :

![Screenshot from 2023-07-27 18-31-48](https://github.com/lingua-libre/RecordWizard/assets/1420189/bcda8490-d166-415b-9f96-cf0610c8f0a1)
![Screenshot from 2023-07-27 18-30-14](https://github.com/lingua-libre/RecordWizard/assets/1420189/1f1a3d02-408e-4223-9c2f-10b3ae34a887)

Allow me to remove that css property then.
